### PR TITLE
Add node to 'kube-node' group only if specified

### DIFF
--- a/k8s_inventory.py
+++ b/k8s_inventory.py
@@ -69,7 +69,8 @@ def nodes_to_hash(network_metadata, group_vars):
             'rack_no':          node['rack_no'],
             'as_number':        node['as_number'],
         }
-        nodes['kube-node']['hosts'].append(node_name)
+        if 'kube_node' in node_roles:
+            nodes['kube-node']['hosts'].append(node_name)
         if 'kube_master' in node_roles:
             nodes['kube-master']['hosts'].append(node_name)
         if 'kube_etcd' in node_roles:


### PR DESCRIPTION
Node roles are specified in network_metadata.yaml file but
k8s_inventory.py adds all nodes to kube-node ansible group. After
this patch only nodes with 'kube_node' role in network_metadata.yaml
will be added to kube-node ansible group.